### PR TITLE
Add names of blocks in the endblock statements

### DIFF
--- a/home/templates/index.html
+++ b/home/templates/index.html
@@ -70,4 +70,4 @@
    </section>
 </div>
 
-{% endblock %}
+{% endblock content %}


### PR DESCRIPTION
As good practice for scalability of code it is good to mention the name of the block which is ending over there. As the codebase grows it becomes challenging to figure out the corresponding block of code.